### PR TITLE
Typo fix: phenal -> phenol

### DIFF
--- a/opensmiles.asciidoc
+++ b/opensmiles.asciidoc
@@ -699,7 +699,7 @@ can also be written:
 |======================================================================================================
 | Depiction                                     | SMILES                      | Name
 .2+| image:depict/phenol-2-amino-ethanol.gif[]  | `c1cc(O.NCCO)ccc1`          | phenol, 2-amino ethanol
-|                                                 `Oc1cc(.NCCO)ccc1`          | phenal, 2-amino ethanol
+|                                                 `Oc1cc(.NCCO)ccc1`          | phenol, 2-amino ethanol
 |======================================================================================================
 
 The second example above is an odd, but legal, use of parentheses and the dot bond, since the


### PR DESCRIPTION
I assume "phenal, 2-amino ethanol" example is actually "phenol, 2-amino ethanol". This PR fixes the typo in `opensmiles.asciidoc`. HTML version should be remade after accepting - I have not committed remade `opensmiles.html` due to large diffs (mostly styling).