### PR TITLE
SMILES descriptor for perhydroisoquinoline lacks a carbon atom

### DIFF
--- a/opensmiles.asciidoc
+++ b/opensmiles.asciidoc
@@ -453,9 +453,9 @@ forms a cyclic structure.
 
 [options="header",frame="topbot",grid="rows",width="90%"]
 |==================================================================================
-| Depiction                               | SMILES           | Name
-| image:depict/cyclohexane.gif[]          | `C1CCCCC1`       | cyclohexane
-| image:depict/perhydroisoquinoline.gif[] | `N1CC2CCCC2CC1`  | perhydroisoquinoline
+| Depiction                               | SMILES            | Name
+| image:depict/cyclohexane.gif[]          | `C1CCCCC1`        | cyclohexane
+| image:depict/perhydroisoquinoline.gif[] | `N1CC2CCCCC2CC1`  | perhydroisoquinoline
 |==================================================================================
 
 If a bond symbol is present between the atom and rnum, it can be

--- a/opensmiles.asciidoc
+++ b/opensmiles.asciidoc
@@ -452,11 +452,11 @@ later in the string, a bond is made between the two atoms, which typically
 forms a cyclic structure.
 
 [options="header",frame="topbot",grid="rows",width="90%"]
-|==================================================================================
+|===================================================================================
 | Depiction                               | SMILES            | Name
 | image:depict/cyclohexane.gif[]          | `C1CCCCC1`        | cyclohexane
 | image:depict/perhydroisoquinoline.gif[] | `N1CC2CCCCC2CC1`  | perhydroisoquinoline
-|==================================================================================
+|===================================================================================
 
 If a bond symbol is present between the atom and rnum, it can be
 present on *either or both* bonded atoms.  However, if it appears on


### PR DESCRIPTION
One of the rings in SMILES descriptor is written as 5-membered, although it should be 6-membered.